### PR TITLE
Remove binary assets and document external sprites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.png
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ This repository contains a Galaga style game implemented purely with HTML, CSS a
 - Ten data driven stages each with unique background, enemy behaviour and optional bosses
 - Optional login to save your progress between sessions
 
+### Customising Images
+Sprites are loaded from `static/images/`. The repository does not include any
+artwork, so copy your own `player.png` and optional `enemy#.png` files into this
+folder. `static/game.js` will automatically pick up the images when you refresh
+the page, allowing you to swap them at any time.
+
 ## Running
 Open `login.html` in a browser or serve the folder with any static file server.
 Logging in stores your current stage using local storage. Playing as a guest does not save progress.


### PR DESCRIPTION
## Summary
- clean repository by removing PNG placeholders
- ignore binaries and bytecode cache
- document that users must supply their own sprite images
- make drawing code handle missing images gracefully

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850cf60daa4832bafd5a6d6d02145f8