### PR TITLE
Add ammo and enemy fire

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This repository contains a Galaga style game implemented purely with HTML, CSS a
 - Keyboard controls (arrow keys for movement and space bar to fire)
 - Enemies with varied patterns, including occasional boss fights
 - Collectible power-ups for shields, rapid fire and spread shots
-- Shooting causes an overheat gauge to fill; overheating disables firing
+- Weapons use a 30 round magazine with a short reload when empty
+- Enemies fire back and damage the player
+- Each stage has a timer and some boss stages change the arena shape
 - Animated star field background and simple explosion effects
 - Stage system with increasing difficulty, score tracking and lives
 - Ten data driven stages each with unique background, enemy behaviour and optional bosses

--- a/game.html
+++ b/game.html
@@ -16,6 +16,7 @@
         <p>Kills: <span id="kills">0</span> / <span id="killsNeeded"></span></p>
         <p>Lives: <span id="lives">3</span> | Score: <span id="score">0</span></p>
         <p>Shield: <span id="shieldStatus">OFF</span></p>
+        <p>Time: <span id="timeLeft">60</span>s | Ammo: <span id="ammo">30</span></p>
         <p id="loginLinks"></p>
     </div>
     <button id="mute">Mute</button>

--- a/templates/game.html
+++ b/templates/game.html
@@ -16,6 +16,7 @@
         <p>Kills: <span id="kills">0</span> / <span id="killsNeeded">{{ stage * 5 }}</span></p>
         <p>Lives: <span id="lives">3</span> | Score: <span id="score">0</span></p>
         <p>Shield: <span id="shieldStatus">OFF</span></p>
+        <p>Time: <span id="timeLeft">60</span>s | Ammo: <span id="ammo">30</span></p>
         {% if logged_in %}
         <p><a href="/logout">Logout</a></p>
         {% else %}


### PR DESCRIPTION
## Summary
- switch player gun to use a 30 round magazine and reload bar
- display remaining ammo and stage timer on screen
- make enemies and bosses shoot bullets
- draw simple arena shapes for boss stages
- update README with new feature list

## Testing
- `pytest -q`
- `node --check static/game.js`


------
https://chatgpt.com/codex/tasks/task_e_685115d2ad2c832b8098b00ea53caea8